### PR TITLE
Add return type to EntityFilters()

### DIFF
--- a/src/behaviors/behaviorFollowEntity.ts
+++ b/src/behaviors/behaviorFollowEntity.ts
@@ -63,7 +63,6 @@ export class BehaviorFollowEntity implements StateBehavior {
      * Cancels the current path finding operation.
      */
   private stopMoving (): void {
-    // @ts-expect-error
     const pathfinder = this.bot.pathfinder
     pathfinder.setGoal(null)
   }
@@ -75,7 +74,6 @@ export class BehaviorFollowEntity implements StateBehavior {
     const entity = this.targets.entity
     if (entity == null) return
 
-    // @ts-expect-error
     const pathfinder = this.bot.pathfinder
 
     const goal = new goals.GoalFollow(entity, this.followDistance)

--- a/src/behaviors/behaviorGetClosestEntity.ts
+++ b/src/behaviors/behaviorGetClosestEntity.ts
@@ -102,7 +102,7 @@ export interface EntityFiltersHeader {
  * Gets a list of many default entity filters which can be applied to
  * default state behaviors.
  */
-export function EntityFilters (): object {
+export function EntityFilters (): EntityFiltersHeader {
   return {
     AllEntities: function (): boolean {
       return true

--- a/src/behaviors/behaviorMoveTo.ts
+++ b/src/behaviors/behaviorMoveTo.ts
@@ -81,7 +81,6 @@ export class BehaviorMoveTo implements StateBehavior {
      * Cancels the current path finding operation.
      */
   private stopMoving (): void {
-    // @ts-expect-error
     const pathfinder = this.bot.pathfinder
     pathfinder.setGoal(null)
   }
@@ -103,7 +102,6 @@ export class BehaviorMoveTo implements StateBehavior {
       console.log(`[MoveTo] Moving from ${this.bot.entity.position.toString()} to ${position.toString()}`)
     }
 
-    // @ts-expect-error
     const pathfinder = this.bot.pathfinder
 
     let goal
@@ -129,7 +127,6 @@ export class BehaviorMoveTo implements StateBehavior {
      * Checks if the bot has finished moving or not.
      */
   isFinished (): boolean {
-    // @ts-expect-error
     const pathfinder: Pathfinder = this.bot.pathfinder
     return !pathfinder.isMoving()
   }


### PR DESCRIPTION
Fixes type errors when using filters from ``EntityFilters()``
```ts
 const { PlayersOnly } = EntityFilters()
 ```
This will no longer error ``Property 'PlayersOnly' does not exist on type '{}'.``