### PR TITLE
Fix lookatplayers.js example

### DIFF
--- a/examples/lookatplayers.js
+++ b/examples/lookatplayers.js
@@ -33,13 +33,13 @@ const {
 // Wait until we spawn
 bot.on('spawn', () => {
   // This targets object is used to pass data between different states. It can be left empty.
-  const targets = {};
+  const targets = {}
   // The idle state makes the bot well, idle.
   const idleState = new BehaviorIdle(bot)
 
   // This state will set targets.entity value to be the closest player.
-  const getClosestPlayer = new BehaviorGetClosestEntity(bot, targets, EntityFilters().PlayersOnly);
-  
+  const getClosestPlayer = new BehaviorGetClosestEntity(bot, targets, EntityFilters().PlayersOnly)
+
   // This state will allow the bot to look at said player.
   const lookAtPlayersState = new BehaviorLookAtEntity(bot, targets)
 
@@ -53,9 +53,9 @@ bot.on('spawn', () => {
       child: getClosestPlayer,
       onTransition: () => bot.chat('hello')
     }),
-	
+
     // We want to start looking at the player immediately after finding them.
-    // Since getClosestPlayer finishes instantly, shouldTransition() should always return true.    
+    // Since getClosestPlayer finishes instantly, shouldTransition() should always return true.
     new StateTransition({
       parent: getClosestPlayer,
       child: lookAtPlayersState,

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "prismarine-entity": "^1.0.0",
     "prismarine-item": "^1.4.0",
     "socket.io": "^4.1.1",
+    "tsc": "^2.0.3",
     "vec3": "^0.1.5"
   },
   "devDependencies": {
@@ -46,7 +47,7 @@
     "@types/socket.io": "^3.0.2",
     "ts-standard": "^10.0.0",
     "typed-emitter": "^1.3.1",
-    "typescript": "^4.0.5"
+    "typescript": "^4.5.4"
   },
   "files": [
     "lib/**/*",


### PR DESCRIPTION
Fixed the *lookatplayers.js* example since it didn't really look at the players when you typed 'hi' in chat.
Now it uses*BehaviorGetClosestEntity* to fetch the closest player and look at it when 'hi' is said in chat.