### PR TITLE
Remove readonly of movements

### DIFF
--- a/src/behaviors/behaviorFollowEntity.ts
+++ b/src/behaviors/behaviorFollowEntity.ts
@@ -14,7 +14,7 @@ export class BehaviorFollowEntity implements StateBehavior {
 
   readonly bot: Bot
   readonly targets: StateMachineTargets
-  readonly movements: Movements
+  movements: Movements
 
   stateName: string = 'followEntity'
   active: boolean = false

--- a/src/behaviors/behaviorMoveTo.ts
+++ b/src/behaviors/behaviorMoveTo.ts
@@ -37,7 +37,6 @@ export class BehaviorMoveTo implements StateBehavior {
   onStateEntered (): void {
     // @ts-expect-error
     this.bot.on('path_update', this.path_update)
-    // @ts-expect-error
     this.bot.on('goal_reached', this.goal_reached)
     this.startMoving()
   }
@@ -45,7 +44,6 @@ export class BehaviorMoveTo implements StateBehavior {
   onStateExited (): void {
     // @ts-expect-error
     this.bot.removeListener('path_update', this.path_update)
-    // @ts-expect-error
     this.bot.removeListener('goal_reached', this.goal_reached)
     this.stopMoving()
   }


### PR DESCRIPTION
Hello I think movements not must be readonly

Because you can configure bot for disable jumps / sprint or something
The idea is get default movements but you can force to change movements configuration