### PR TITLE
Add auto publish version on new tag versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: Build and deploy module
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: write
+jobs:
+  release:
+    name: "Publish package to NPM"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14.5.0
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - run: npm run build-module
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,23 +1,36 @@
-name: Build and deploy module
+name: npm-publish
 on:
   push:
-    tags:
-      - v*
-
-permissions:
-  contents: write
+    branches:
+      - auto_publish_npm_version # Change this to your default branch
 jobs:
-  release:
-    name: "Publish package to NPM"
+  npm-publish:
+    name: npm-publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Checkout repository
+        uses: actions/checkout@master
+      - name: Set up Node.js
+        uses: actions/setup-node@master
         with:
           node-version: 14.5.0
-          registry-url: "https://registry.npmjs.org"
+      - name: Install dependencies
       - run: npm ci
-      - run: npm run build-module
-      - run: npm publish
+      - name: Build
+      - run: npm run build
+      - id: publish
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_AUTH_TOKEN }}
+      - name: Create Release
+        if: steps.publish.outputs.type != 'none'
+        id: create_release
+        uses: actions/create-release@v1
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.publish.outputs.version }}
+          release_name: Release ${{ steps.publish.outputs.version }}
+          body: ${{ steps.publish.outputs.version }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,9 @@ jobs:
         with:
           node-version: 14.5.0
       - name: Install dependencies
-      - run: npm ci
+        run: npm ci
       - name: Build
-      - run: npm run build
+        run: npm run build
       - id: publish
         uses: JS-DevTools/npm-publish@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: 14.5.0
       - name: Install dependencies
-        run: npm ci
+        run: npm install
       - name: Build
         run: npm run build
       - id: publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: npm-publish
 on:
   push:
     branches:
-      - auto_publish_npm_version # Change this to your default branch
+      - master # Change this to your default branch
 jobs:
   npm-publish:
     name: npm-publish

--- a/src/webserver.ts
+++ b/src/webserver.ts
@@ -95,9 +95,9 @@ export class StateMachineWebserver {
     const nestGroups = this.getNestGroups()
 
     const packet: StateMachineStructurePacket = {
-      states: states,
-      transitions: transitions,
-      nestGroups: nestGroups
+      states,
+      transitions,
+      nestGroups
     }
 
     socket.emit('connected', packet)
@@ -118,7 +118,7 @@ export class StateMachineWebserver {
     }
 
     const packet: StateMachineUpdatePacket = {
-      activeStates: activeStates
+      activeStates
     }
 
     socket.emit('stateChanged', packet)


### PR DESCRIPTION
Hi guys I saw still in npm version 1.6.5 to avoid forgot to upload new version to npm i added auto deployment

Only is needed to push a new tag with the versión: v1.X.X

They can be used easy with npm:
npm version (major | minor | patch)

But is needed to configure token of npm into github