### PR TITLE
Remove readonly for movements

### DIFF
--- a/src/behaviors/behaviorMoveTo.ts
+++ b/src/behaviors/behaviorMoveTo.ts
@@ -15,7 +15,7 @@ export class BehaviorMoveTo implements StateBehavior {
   private readonly bot: Bot
 
   readonly targets: StateMachineTargets
-  readonly movements: Movements
+  movements: Movements
   stateName: string = 'moveTo'
   active: boolean = false
   x?: number


### PR DESCRIPTION
Samte this PR: https://github.com/PrismarineJS/mineflayer-statemachine/pull/151

But i forgot remove readonly in the behavior of "move to"

Must be dont reandonly to "modify" the default behavior