### PR TITLE
Fix avoid duplicated button in layout on reload

### DIFF
--- a/examples/lookatplayers.js
+++ b/examples/lookatplayers.js
@@ -3,14 +3,14 @@
  */
 const mineflayer = require('mineflayer')
 
-if (process.argv.length < 4 || process.argv.length > 6) {
+if (process.argv.length < 3 || process.argv.length > 6) {
   console.log('Usage : node lookatplayers.js <host> <port> [<name>] [<password>]')
   process.exit(1)
 }
 
 const bot = mineflayer.createBot({
   host: process.argv[2],
-  port: parseInt(process.argv[3]),
+  port: process.argv[3] ? parseInt(process.argv[3]) : 25565,
   username: process.argv[4] ? process.argv[4] : 'statemachine_bot',
   password: process.argv[5]
 })

--- a/examples/webserver.js
+++ b/examples/webserver.js
@@ -1,13 +1,13 @@
 const mineflayer = require('mineflayer')
 
-if (process.argv.length < 4 || process.argv.length > 6) {
+if (process.argv.length < 3 || process.argv.length > 6) {
   console.log('Usage : node webserver.js <host> <port> [<name>] [<password>]')
   process.exit(1)
 }
 
 const bot = mineflayer.createBot({
   host: process.argv[2],
-  port: parseInt(process.argv[3]),
+  port: process.argv[3] ? parseInt(process.argv[3]) : 25565,
   username: process.argv[4] ? process.argv[4] : 'statemachine_bot',
   password: process.argv[5]
 })

--- a/web/index.js
+++ b/web/index.js
@@ -36,6 +36,9 @@ class Graph {
   }
 
   clear () {
+    const buttonGroup = document.getElementById('layerButtons')
+    buttonGroup.textContent = '';
+    
     this.states = []
     this.transitions = []
     this.repaint = true


### PR DESCRIPTION
Hello, this PR fix a small bug when the boot is reloaded and is reconnected,

That produces to duplicate layout:

![ezgif-3-a94b30477e](https://user-images.githubusercontent.com/20754836/214155056-ec40da26-c874-42c8-83e3-252e9eb0ef7b.gif)

This can be fixed easily clearing correct inner layout in clear function
