### PR TITLE
bind methods to class instance with arrow syntax

### DIFF
--- a/src/statemachine.ts
+++ b/src/statemachine.ts
@@ -181,7 +181,7 @@ export class BotStateMachine extends EventEmitter {
     this.rootStateMachine.onStateEntered()
   }
 
-  private findNestedStateMachines = (nested: NestedStateMachine, depth: number = 0): void => {
+  private readonly findNestedStateMachines = (nested: NestedStateMachine, depth: number = 0): void => {
     this.nestedStateMachines.push(nested)
     nested.depth = depth
 
@@ -192,7 +192,7 @@ export class BotStateMachine extends EventEmitter {
     }
   }
 
-  private findStatesRecursive = (nested: NestedStateMachine): void => {
+  private readonly findStatesRecursive = (nested: NestedStateMachine): void => {
     for (const state of nested.states) {
       this.states.push(state)
 
@@ -200,7 +200,7 @@ export class BotStateMachine extends EventEmitter {
     }
   }
 
-  private findTransitionsRecursive = (nested: NestedStateMachine): void => {
+  private readonly findTransitionsRecursive = (nested: NestedStateMachine): void => {
     for (const trans of nested.transitions) { this.transitions.push(trans) }
 
     for (const state of nested.states) {
@@ -211,7 +211,7 @@ export class BotStateMachine extends EventEmitter {
   /**
      * Called each tick to update the root state machine.
      */
-  private update = (): void => {
+  private readonly update = (): void => {
     this.rootStateMachine.update()
   }
 }
@@ -308,7 +308,7 @@ export class NestedStateMachine extends EventEmitter implements StateBehavior {
     this.states = this.findStates()
   }
 
-  private findStates = (): StateBehavior[] => {
+  private readonly findStates = (): StateBehavior[] => {
     const states = []
     states.push(this.enter)
 

--- a/src/statemachine.ts
+++ b/src/statemachine.ts
@@ -101,7 +101,7 @@ export class StateTransition {
      * @throws Exception if this transition is not yet bound to a
      * state machine.
      */
-  trigger (): void {
+  trigger = (): void => {
     if (!this.parentState.active) { return }
 
     this.triggerState = true
@@ -113,14 +113,14 @@ export class StateTransition {
      *
      * @returns True if this transition was triggered to occur.
      */
-  isTriggered (): boolean {
+  isTriggered = (): boolean => {
     return this.triggerState
   }
 
   /**
      * Resets the triggered state to false.
      */
-  resetTrigger (): void {
+  resetTrigger = (): void => {
     this.triggerState = false
   }
 }
@@ -181,7 +181,7 @@ export class BotStateMachine extends EventEmitter {
     this.rootStateMachine.onStateEntered()
   }
 
-  private findNestedStateMachines (nested: NestedStateMachine, depth: number = 0): void {
+  private findNestedStateMachines = (nested: NestedStateMachine, depth: number = 0): void => {
     this.nestedStateMachines.push(nested)
     nested.depth = depth
 
@@ -192,7 +192,7 @@ export class BotStateMachine extends EventEmitter {
     }
   }
 
-  private findStatesRecursive (nested: NestedStateMachine): void {
+  private findStatesRecursive = (nested: NestedStateMachine): void => {
     for (const state of nested.states) {
       this.states.push(state)
 
@@ -200,7 +200,7 @@ export class BotStateMachine extends EventEmitter {
     }
   }
 
-  private findTransitionsRecursive (nested: NestedStateMachine): void {
+  private findTransitionsRecursive = (nested: NestedStateMachine): void => {
     for (const trans of nested.transitions) { this.transitions.push(trans) }
 
     for (const state of nested.states) {
@@ -211,7 +211,7 @@ export class BotStateMachine extends EventEmitter {
   /**
      * Called each tick to update the root state machine.
      */
-  private update (): void {
+  private update = (): void => {
     this.rootStateMachine.update()
   }
 }
@@ -308,7 +308,7 @@ export class NestedStateMachine extends EventEmitter implements StateBehavior {
     this.states = this.findStates()
   }
 
-  private findStates (): StateBehavior[] {
+  private findStates = (): StateBehavior[] => {
     const states = []
     states.push(this.enter)
 
@@ -329,7 +329,7 @@ export class NestedStateMachine extends EventEmitter implements StateBehavior {
     return states
   }
 
-  onStateEntered (): void {
+  onStateEntered = (): void => {
     this.activeState = this.enter
     this.activeState.active = true
     this.activeState.onStateEntered?.()
@@ -339,7 +339,7 @@ export class NestedStateMachine extends EventEmitter implements StateBehavior {
     this.emit('stateChanged')
   }
 
-  update (): void {
+  update = (): void => {
     this.activeState?.update?.()
 
     for (let i = 0; i < this.transitions.length; i++) {
@@ -366,7 +366,7 @@ export class NestedStateMachine extends EventEmitter implements StateBehavior {
     }
   }
 
-  onStateExited (): void {
+  onStateExited = (): void => {
     if (this.activeState == null) return
 
     this.activeState.active = false
@@ -377,7 +377,7 @@ export class NestedStateMachine extends EventEmitter implements StateBehavior {
   /**
      * Checks whether or not this state machine layer has finished running.
      */
-  isFinished (): boolean {
+  isFinished = (): boolean => {
     if (this.active == null) return true
     if (this.exit == null) return false
 


### PR DESCRIPTION
I ran into an issue while trying to implement `NestedStateMachine`.

What I discovered:
When trying to pass a reference to `myNestedStateMachine.isFinished` directly to a `StateTransition`, context is not defined. This is due to the fact that class methods don't inherit the prototype by default.

``` broken.js
new StateTransition({
  parent: myNestedStateMachine,
  child: behaviorNextState,
  shouldTransition: myNestedStateMachine.isFinished // this doesn't work.
})
```

This works, however, I believe the above should be acceptable
``` working.js
new StateTransition({
  parent: myNestedStateMachine,
  child: behaviorNextState,
  shouldTransition: () => myNestedStateMachine.isFinished()
})
```

Solution: Bind methods to class instance. Feel free to modify or reject as you see fit :)

Side note: This is my first OSS contribution; feedback is welcome!
