### PR TITLE
fix physicTick-event deprecation

### DIFF
--- a/src/statemachine.ts
+++ b/src/statemachine.ts
@@ -175,7 +175,7 @@ export class BotStateMachine extends EventEmitter {
     this.findTransitionsRecursive(this.rootStateMachine)
     this.findNestedStateMachines(this.rootStateMachine)
 
-    this.bot.on('physicTick', () => this.update())
+    this.bot.on('physicsTick', () => this.update())
 
     this.rootStateMachine.active = true
     this.rootStateMachine.onStateEntered()


### PR DESCRIPTION
when using mineflayer-statemachine with newest version of mineflayer it logs a deprecation warning in the console:
```Mineflayer detected that you are using a deprecated event (physicTick)! Please use this event (physicsTick) instead.```

this pr follows the recommendation and uses the `physicsTick` event.