### PR TITLE
Fix build (CI)

### DIFF
--- a/src/behaviors/behaviorFollowEntity.ts
+++ b/src/behaviors/behaviorFollowEntity.ts
@@ -2,7 +2,6 @@ import { StateBehavior, StateMachineTargets } from '../statemachine'
 import { Bot } from 'mineflayer'
 import { Entity } from 'prismarine-entity'
 import { Movements, goals } from 'mineflayer-pathfinder'
-import mcDataLoader from 'minecraft-data'
 
 /**
  * Causes the bot to follow the target entity.
@@ -10,8 +9,6 @@ import mcDataLoader from 'minecraft-data'
  * This behavior relies on the mineflayer-pathfinding plugin to be installed.
  */
 export class BehaviorFollowEntity implements StateBehavior {
-  private readonly mcData: any
-
   readonly bot: Bot
   readonly targets: StateMachineTargets
   movements: Movements
@@ -29,7 +26,6 @@ export class BehaviorFollowEntity implements StateBehavior {
   constructor (bot: Bot, targets: StateMachineTargets) {
     this.bot = bot
     this.targets = targets
-    this.mcData = mcDataLoader(this.bot.version)
     this.movements = new Movements(this.bot)
   }
 

--- a/src/behaviors/behaviorFollowEntity.ts
+++ b/src/behaviors/behaviorFollowEntity.ts
@@ -30,7 +30,7 @@ export class BehaviorFollowEntity implements StateBehavior {
     this.bot = bot
     this.targets = targets
     this.mcData = mcDataLoader(this.bot.version)
-    this.movements = new Movements(this.bot, this.mcData)
+    this.movements = new Movements(this.bot)
   }
 
   onStateEntered (): void {

--- a/src/behaviors/behaviorMoveTo.ts
+++ b/src/behaviors/behaviorMoveTo.ts
@@ -4,8 +4,6 @@ import { Bot } from 'mineflayer'
 import { Movements, goals, Pathfinder, ComputedPath } from 'mineflayer-pathfinder'
 import { Vec3 } from 'vec3'
 
-import mcDataLoader from 'minecraft-data'
-
 /**
  * Causes the bot to move to the target position.
  *

--- a/src/behaviors/behaviorMoveTo.ts
+++ b/src/behaviors/behaviorMoveTo.ts
@@ -32,8 +32,7 @@ export class BehaviorMoveTo implements StateBehavior {
     this.bot = bot
     this.targets = targets
 
-    const mcData = mcDataLoader(bot.version)
-    this.movements = new Movements(bot, mcData)
+    this.movements = new Movements(bot)
   }
 
   onStateEntered (): void {


### PR DESCRIPTION
last year with the prismarine-registry refactoring the Movements class of mineflayer-pathfinder no longer requires an mcData argument: https://github.com/PrismarineJS/mineflayer-pathfinder/commit/c2f4d2551d07d301b2cc3f55fdc75573dae61f06

this was not adjusted for in mineflayer-statemachine and nobody cared because it caused no errors, but recently dependabot upgraded typescript: https://github.com/PrismarineJS/mineflayer-statemachine/commit/98004dee5210b3cbff8f9e6deddf6252e78580a3

with this update typescript probably somehow detects the superfluous mcData argument and the build fails

this pr removes the unnecessary additional argument, thus fixing the build