### PR TITLE
Added support to use behind proxy

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,10 +4,10 @@
 <head>
     <title>Mineflayer StateMachine</title>
 
-    <link rel="stylesheet" type="text/css" href="/web/index.css" />
+    <link rel="stylesheet" type="text/css" href="./web/index.css" />
 
-    <script src="/socket.io/socket.io.js"></script>
-    <script src="/web/index.js"></script>
+    <script src="./socket.io/socket.io.js"></script>
+    <script src=".//web/index.js"></script>
 </head>
 
 <body onload="init()">

--- a/web/index.js
+++ b/web/index.js
@@ -504,7 +504,9 @@ function init () {
   graph = new Graph(canvas)
   nestedGroups = []
 
-  const socket = io()
+  const socket = io({
+    path: window.location.pathname + 'socket.io'
+  })
   socket.on('connected', packet => onConnected(packet))
   socket.on('stateChanged', packet => onStateChanged(packet))
 }


### PR DESCRIPTION
Hi guys whit that changes add support to use proxy

Example using express:
![image](https://github.com/PrismarineJS/mineflayer-statemachine/assets/20754836/1b9818aa-b939-4374-8c48-59ece2cdf1ee)

With that can you make a dynamic proxy to avoid open multiple ports to different bots