### PR TITLE
make webserver stoppable once created

### DIFF
--- a/src/webserver.ts
+++ b/src/webserver.ts
@@ -8,8 +8,6 @@ import { globalSettings } from '.'
 
 const publicFolder = './../web'
 
-// TODO Add option to shutdown server
-
 /**
  * A web server which allows users to view the current state of the
  * bot behavior state machine.


### PR DESCRIPTION
If the bot starting process includes creating a webserver you can't replay it because the default port is already bound and can't be freed
this pr makes freeing possible by adding a stopServer() method

That's useful if you have to recreate your bot sometimes (possibly due to disconnects) but don't want to recreate the whole node process